### PR TITLE
Make it possible to write STAC v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,29 @@ pip install git+https://github.com/MAAP-project/icesat2-boreal-stac.git@main
 ```
 
 ## Usage
-
-> [!NOTE]
-> You need to be authenticated with MAAP SMCE AWS credentials to access the files in these buckets:
+>
+> [!WARNING]
+> By default, this package will create STAC v1.1.0 collections and items!
+>
+> Use `pystac.set_stac_version` or the `PYSTAC_STAC_VERSION_OVERRIDE` environment variable to set it to version 1.0.0 if you need that for your catalog.
 
 To create collections:
 
 ```python
+from pystac import set_stac_version
 from icesat2_boreal_stac.stac import create_collection, Variable
+
+# optional: set STAC version to 1.0.0
+# set_stac_version("1.0.0")
 
 agb_collection = create_collection(Variable.AGB)
 ht_collection = create_collection(Variable.HT)
 ```
 
 To create items, specify the key to the COG asset for this item. The package assumes that the other asset(s) (e.g. train_data.csv) are located alongside the COG asset in a folder in S3.
+
+> [!NOTE]
+> You need to be authenticated with MAAP SMCE AWS credentials to access the files in these buckets:
 
 ```python
 from icesat2_boreal_stac.stac import create_item

--- a/examples/agb/boreal_agb_2020_202411251732556086_0000004/boreal_agb_2020_202411251732556086_0000004.json
+++ b/examples/agb/boreal_agb_2020_202411251732556086_0000004/boreal_agb_2020_202411251732556086_0000004.json
@@ -2,8 +2,7 @@
   "type": "Feature",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
   ],
   "id": "boreal_agb_2020_202411251732556086_0000004",
   "geometry": {
@@ -121,7 +120,7 @@
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Gridded predictions of aboveground biomass (Mg/ha)",
       "description": "Gridded predictions of aboveground biomass (Mg/ha)",
-      "raster:bands": [
+      "bands": [
         {
           "data_type": "float32",
           "scale": 1.0,

--- a/examples/ht/boreal_ht_2020_202501131736787421_0000004/boreal_ht_2020_202501131736787421_0000004.json
+++ b/examples/ht/boreal_ht_2020_202501131736787421_0000004/boreal_ht_2020_202501131736787421_0000004.json
@@ -2,8 +2,7 @@
   "type": "Feature",
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
   ],
   "id": "boreal_ht_2020_202501131736787421_0000004",
   "geometry": {
@@ -121,7 +120,7 @@
       "type": "image/tiff; application=geotiff; profile=cloud-optimized",
       "title": "Gridded predictions of vegetation height (m)",
       "description": "Gridded predictions of vegetation height (m)",
-      "raster:bands": [
+      "bands": [
         {
           "data_type": "float32",
           "scale": 1.0,

--- a/icesat2_boreal_stac/__init__.py
+++ b/icesat2_boreal_stac/__init__.py
@@ -1,3 +1,3 @@
 """icesat2-boreal-stac"""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,9 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "rio-stac",
-    "pystac[validation]",
+    "pystac[validation]>=1.12.0",
     "boto3",
+    "semver>=3.0.4",
 ]
 
 [dependency-groups]
@@ -77,6 +78,7 @@ lint.select = [
     "W",  # pycodestyle warnings
     "C",  # flake8-comprehensions
     "B",  # flake8-bugbear
+    "F401", # unused imports
 ]
 
 line-length = 88

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,3 +78,19 @@ def mock_cog_key_to_asset_keys(monkeypatch):
     monkeypatch.setattr(
         "icesat2_boreal_stac.stac.cog_key_to_asset_keys", mock_cog_key_to_asset_keys
     )
+
+
+@pytest.fixture(scope="function")
+def stac_v1_0_0():
+    """Set a custom environment variable for testing."""
+    var = "PYSTAC_STAC_VERSION_OVERRIDE"
+    original_value = os.getenv(var)
+
+    os.environ[var] = "1.0.0"
+
+    yield
+
+    if original_value is not None:
+        os.environ[var] = original_value
+    else:
+        del os.environ[var]

--- a/uv.lock
+++ b/uv.lock
@@ -30,30 +30,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.36.7"
+version = "1.36.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/6e/afd7d74538a1684a3d5a5c2c7ca7c57f89ac6be3cae813e9466be135a25b/boto3-1.36.7.tar.gz", hash = "sha256:ae98634efa7b47ced1b0d7342e2940b32639eee913f33ab406590b8ed55ee94b", size = 111024 }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/fa/b688fdda8aff3743745afe04ae6df70b9480f00d0b1b051e06b0f7389088/boto3-1.36.8.tar.gz", hash = "sha256:ac47215d320b0c2534340db58d6d5284cb1860b7bff172b4dd6eee2dee1d5779", size = 111042 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/80/62432ed0f0a54a25c6cbab911eebb0e6c25b09de3ec42670089f91b978c9/boto3-1.36.7-py3-none-any.whl", hash = "sha256:ab501f75557863e2d2c9fa731e4fe25c45f35e0d92ea0ee11a4eaa63929d3ede", size = 139167 },
+    { url = "https://files.pythonhosted.org/packages/8e/59/58cff44147802cb20a6d185e4e18df19b7238566195114adc6397e0c8dbb/boto3-1.36.8-py3-none-any.whl", hash = "sha256:7f61c9d0ea64f484a17c1e3115fdf90fd7b17ab6771e07cb4549f42b9fd28fb9", size = 139167 },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.36.7"
+version = "1.36.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/93/d9188c30f4c3c674cd3ee893efc23fab748e311231b4c376972453f77316/botocore-1.36.7.tar.gz", hash = "sha256:9abc64bde5e7d8f814ea91d6fc0a8142511fc96427c19fe9209677c20a0c9e6e", size = 13481743 }
+sdist = { url = "https://files.pythonhosted.org/packages/23/a6/7b526b42ba24e6ef482cdd98d3caca31e96ed0595b8b994b09e807a10d44/botocore-1.36.8.tar.gz", hash = "sha256:81c88e5566cf018e1411a68304dc1fb9e4156ca2b50a3a0f0befc274299e67fa", size = 13490469 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/67/c817051cbe5102dccf13f354a3f2169e1ace30b7ceb7947792af1691f6b9/botocore-1.36.7-py3-none-any.whl", hash = "sha256:a6c6772d777af2957ac9975207fac1ccc4ce101408b85e9b5e3c5ba0bb949102", size = 13310055 },
+    { url = "https://files.pythonhosted.org/packages/3e/05/43bae794c8e5f42d79e1c24205bc0c7447b3909a446de46cf231fa6b39dd/botocore-1.36.8-py3-none-any.whl", hash = "sha256:59d3fdfbae6d916b046e973bebcbeb70a102f9e570ca86d5ba512f1854b78fc2", size = 13318382 },
 ]
 
 [[package]]
@@ -394,12 +394,13 @@ wheels = [
 
 [[package]]
 name = "icesat2-boreal-stac"
-version = "2.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "pystac", extra = ["validation"] },
     { name = "rio-stac" },
+    { name = "semver" },
 ]
 
 [package.dev-dependencies]
@@ -417,8 +418,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "boto3" },
-    { name = "pystac", extras = ["validation"] },
+    { name = "pystac", extras = ["validation"], specifier = ">=1.12.0" },
     { name = "rio-stac" },
+    { name = "semver", specifier = ">=3.0.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -1199,6 +1201,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/45/2323b5928f86fd29f9afdcef4659f68fa73eaa5356912b774227f5cf46b5/s3transfer-0.11.2.tar.gz", hash = "sha256:3b39185cb72f5acc77db1a58b6e25b977f28d20496b6e58d6813d75f464d632f", size = 147885 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/ac/e7dc469e49048dc57f62e0c555d2ee3117fa30813d2a1a2962cce3a2a82a/s3transfer-0.11.2-py3-none-any.whl", hash = "sha256:be6ecb39fadd986ef1701097771f87e4d2f821f27f6071c872143884d2950fbc", size = 84151 },
+]
+
+[[package]]
+name = "semver"
+version = "3.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912 },
 ]
 
 [[package]]


### PR DESCRIPTION
STAC v1.1.0 ingestion is blocked by https://github.com/developmentseed/eoapi-cdk/issues/119

Since some extensions are now built into v1.1.0 we need to make sure they are declared when writing v1.0.0!