### PR TITLE
feat: expand the list of providers for the collections

### DIFF
--- a/examples/agb/collection.json
+++ b/examples/agb/collection.json
@@ -146,14 +146,39 @@
   "license": "CC-BY",
   "providers": [
     {
-      "name": "MAAP",
-      "description": "The MAAP platform is designed to combine data, algorithms, and computational abilities for the processing and sharing of data related to NASA\u2019s GEDI, ESA\u2019s BIOMASS, and NASA/ISRO\u2019s NISAR missions",
+      "name": "UMD/GEOG",
+      "description": "Department of Geographical Sciences, University of Maryland",
+      "roles": [
+        "producer",
+        "licensor"
+      ],
+      "url": "https://geog.umd.edu/"
+    },
+    {
+      "name": "NASA/GSFC",
+      "description": "Goddard Space Flight Center",
+      "roles": [
+        "producer",
+        "licensor"
+      ],
+      "url": "https://gsfc.nasa.gov"
+    },
+    {
+      "name": "UTX-AUSTIN/CSR",
+      "description": "Center for Space Research, University of Texas at Austin",
+      "roles": [
+        "producer",
+        "licensor"
+      ],
+      "url": "http://www.csr.utexas.edu/"
+    },
+    {
+      "name": "NASA/MAAP",
+      "description": "The ESA-NASA Multi-Mission Algorithm and Analysis Platform",
       "roles": [
         "processor",
-        "producer",
         "host"
       ],
-      "url": "https://maap-project.org",
       "processing:level": "L4"
     }
   ],

--- a/examples/agb/collection.json
+++ b/examples/agb/collection.json
@@ -156,7 +156,7 @@
     },
     {
       "name": "NASA/GSFC",
-      "description": "Goddard Space Flight Center",
+      "description": "Goddard Space Flight Center, NASA",
       "roles": [
         "producer",
         "licensor"

--- a/examples/ht/collection.json
+++ b/examples/ht/collection.json
@@ -137,7 +137,7 @@
     },
     {
       "name": "NASA/GSFC",
-      "description": "Goddard Space Flight Center",
+      "description": "Goddard Space Flight Center, NASA",
       "roles": [
         "producer",
         "licensor"

--- a/examples/ht/collection.json
+++ b/examples/ht/collection.json
@@ -127,14 +127,39 @@
   "license": "CC-BY",
   "providers": [
     {
-      "name": "MAAP",
-      "description": "The MAAP platform is designed to combine data, algorithms, and computational abilities for the processing and sharing of data related to NASA\u2019s GEDI, ESA\u2019s BIOMASS, and NASA/ISRO\u2019s NISAR missions",
+      "name": "UMD/GEOG",
+      "description": "Department of Geographical Sciences, University of Maryland",
+      "roles": [
+        "producer",
+        "licensor"
+      ],
+      "url": "https://geog.umd.edu/"
+    },
+    {
+      "name": "NASA/GSFC",
+      "description": "Goddard Space Flight Center",
+      "roles": [
+        "producer",
+        "licensor"
+      ],
+      "url": "https://gsfc.nasa.gov"
+    },
+    {
+      "name": "UTX-AUSTIN/CSR",
+      "description": "Center for Space Research, University of Texas at Austin",
+      "roles": [
+        "producer",
+        "licensor"
+      ],
+      "url": "http://www.csr.utexas.edu/"
+    },
+    {
+      "name": "NASA/MAAP",
+      "description": "The ESA-NASA Multi-Mission Algorithm and Analysis Platform",
       "roles": [
         "processor",
-        "producer",
         "host"
       ],
-      "url": "https://maap-project.org",
       "processing:level": "L4"
     }
   ],

--- a/src/stactools/icesat2_boreal/constants.py
+++ b/src/stactools/icesat2_boreal/constants.py
@@ -124,7 +124,7 @@ PROVIDERS = [
     ),
     Provider(
         name="NASA/GSFC",
-        description="Goddard Space Flight Center",
+        description="Goddard Space Flight Center, NASA",
         url="https://gsfc.nasa.gov",
         roles=[ProviderRole.PRODUCER, ProviderRole.LICENSOR],
     ),

--- a/src/stactools/icesat2_boreal/constants.py
+++ b/src/stactools/icesat2_boreal/constants.py
@@ -117,18 +117,32 @@ PROCESSING_LEVEL = "L4"
 
 PROVIDERS = [
     Provider(
-        name="MAAP",
-        description="The MAAP platform is designed to combine data, algorithms, and "
-        "computational abilities for the processing and sharing of data related to "
-        "NASA’s GEDI, ESA’s BIOMASS, and NASA/ISRO’s NISAR missions",
-        url="https://maap-project.org",
+        name="UMD/GEOG",
+        description="Department of Geographical Sciences, University of Maryland",
+        url="https://geog.umd.edu/",
+        roles=[ProviderRole.PRODUCER, ProviderRole.LICENSOR],
+    ),
+    Provider(
+        name="NASA/GSFC",
+        description="Goddard Space Flight Center",
+        url="https://gsfc.nasa.gov",
+        roles=[ProviderRole.PRODUCER, ProviderRole.LICENSOR],
+    ),
+    Provider(
+        name="UTX-AUSTIN/CSR",
+        description="Center for Space Research, University of Texas at Austin",
+        url="http://www.csr.utexas.edu/",
+        roles=[ProviderRole.PRODUCER, ProviderRole.LICENSOR],
+    ),
+    Provider(
+        name="NASA/MAAP",
+        description="The ESA-NASA Multi-Mission Algorithm and Analysis Platform",
         roles=[
             ProviderRole.PROCESSOR,
-            ProviderRole.PRODUCER,
             ProviderRole.HOST,
         ],
         extra_fields={"processing:level": PROCESSING_LEVEL},
-    )
+    ),
 ]
 
 SUMMARIES = Summaries(

--- a/uv.lock
+++ b/uv.lock
@@ -1563,7 +1563,7 @@ wheels = [
 
 [[package]]
 name = "stactools-icesat2-boreal"
-version = "0.3.0"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "pystac", extra = ["validation"] },


### PR DESCRIPTION
This adds proper assignment of the 'licensor' and 'producer' roles to the collaborators' institutions, brings the NASA/MAAP provider up to date with other collections.